### PR TITLE
fix: remove {.global.} from arg in bindCallback

### DIFF
--- a/webview.nim
+++ b/webview.nim
@@ -412,7 +412,7 @@ proc bindCallback*(w: Webview; name: string;
   
   #      using global seems to work...
   # TODO is there a better solution?
-  let arg {.global.} = CallBackContext(w: w, fn: fn)
+  let arg = CallBackContext(w: w, fn: fn)
 
   result = w.webviewBind(name, closure, cast[pointer](arg))
 

--- a/webview.nim
+++ b/webview.nim
@@ -409,9 +409,6 @@ proc bindCallback*(w: Webview; name: string;
                  fn: proc (id: string; req: JsonNode): string): WebviewError {.discardable.} =
   ## Essentially a high-level version of
   ## `webviewBind <#webviewBind,Webview,cstring,proc(cstring,cstring,pointer),pointer>`_
-  
-  #      using global seems to work...
-  # TODO is there a better solution?
   let arg = CallBackContext(w: w, fn: fn)
 
   result = w.webviewBind(name, closure, cast[pointer](arg))


### PR DESCRIPTION
global is breaking in latest nim versions, removing it solved the problem for me. I'm a newbie in nim/webview development, but I think this shouldn't be much trouble to remove from what I tested.